### PR TITLE
Refactor error handling and add Arena of Valor API endpoint

### DIFF
--- a/src/8-ball-pool/index.ts
+++ b/src/8-ball-pool/index.ts
@@ -18,15 +18,11 @@ export default new Elysia().get("/8-ball-pool", ({ query: { id } }) => EightBall
 
       return {
         success: false,
-        errors: error.all
-          .filter((e) => e.type === 54)
-          .map((e) => {
-            return {
-              path: e.path,
-              message: e.message,
-              summary: e.summary,
-            };
-          }),
+        errors: error.all.map((e) => ({
+          path: e.path,
+          message: e.message,
+          summary: e.summary,
+        })),
       };
     }
   },

--- a/src/8-ball-pool/model.ts
+++ b/src/8-ball-pool/model.ts
@@ -4,7 +4,7 @@ import { Error, Model as BaseModel } from "../utils/model.js";
 
 export const Model = {
   query: BaseModel.query({
-    id: t.String({ description: "ID akun yang mau dicek", example: "2180533717" }),
+    id: t.String({ pattern: "^[0-9]+$", description: "ID akun yang mau dicek", example: "2180533717" }),
   }),
   success: BaseModel.success(
     {

--- a/src/8-ball-pool/service.ts
+++ b/src/8-ball-pool/service.ts
@@ -6,10 +6,8 @@ import { AccountNotFoundError } from "../utils/errors.js";
 
 import { Response } from "../types/helper.js";
 
-type Success = UnwrapSchema<typeof Model.success>;
-
 export const EightBallPool = {
-  async check({ id }: UnwrapSchema<typeof Model.query>): Promise<Response<Success>> {
+  async check({ id }: UnwrapSchema<typeof Model.query>): Promise<Response<UnwrapSchema<typeof Model.success>>> {
     const data = await Fetcher.codashop({
       vpp: { id: "205678", price: "140000", vp: "0" },
       user: { userId: id, zoneId: "" },

--- a/src/8-ball-pool/service.ts
+++ b/src/8-ball-pool/service.ts
@@ -16,7 +16,7 @@ export const EightBallPool = {
       voucherTypeName: "EIGHT_BALL_POOL",
     });
 
-    if (data.errorCode == "-100") {
+    if (data.errorCode === "-100") {
       throw new AccountNotFoundError();
     }
 

--- a/src/arena-of-valor/index.ts
+++ b/src/arena-of-valor/index.ts
@@ -1,0 +1,35 @@
+import { Elysia } from "elysia";
+
+import { Model } from "./model.js";
+
+import { Error } from "../utils/model.js";
+import { ArenaOfValor } from "./service.js";
+
+export default new Elysia().get("/arena-of-valor", ({ query: { id } }) => ArenaOfValor.check({ id }), {
+  query: Model.query,
+  response: {
+    200: Model.success,
+    400: Model.badRequest,
+    404: Error.notFound,
+    503: Error.serverError,
+  },
+  error({ error, code, set }) {
+    if (code === "VALIDATION") {
+      set.status = "Bad Request";
+
+      return {
+        success: false,
+        errors: error.all.map((e) => ({
+          path: e.path,
+          message: e.message,
+          summary: e.summary,
+        })),
+      };
+    }
+  },
+  detail: {
+    summary: "Arena of Valor",
+    description:
+      "game MOBA mobile yang dikembangkan oleh TiMi Studios, di mana pemain bertarung dalam tim 5v5 untuk menghancurkan base lawan dengan strategi, kerja sama, dan pemilihan hero yang tepat",
+  },
+});

--- a/src/arena-of-valor/model.ts
+++ b/src/arena-of-valor/model.ts
@@ -1,0 +1,28 @@
+import { t } from "elysia";
+
+import { Model as BaseModel, Error } from "../utils/model.js";
+
+export const Model = {
+  query: BaseModel.query({
+    id: t.String({ pattern: "^[0-9]+$", description: "ID akun yang mau dicek", example: "888347346994333" }),
+  }),
+  success: BaseModel.success(
+    {
+      id: t.String({ description: "ID akun" }),
+    },
+    {
+      game: "Arena of Valor",
+      account: {
+        id: "888347346994333",
+        ign: "BangRams",
+      },
+    },
+  ),
+  badRequest: Error.badRequest([
+    {
+      path: "/id",
+      message: "Expected string",
+      summary: "Expected property 'id' to be string but found: undefined",
+    },
+  ]),
+};

--- a/src/arena-of-valor/service.ts
+++ b/src/arena-of-valor/service.ts
@@ -11,7 +11,7 @@ export const ArenaOfValor = {
   async check({ id }: UnwrapSchema<typeof Model.query>): Promise<Response<UnwrapSchema<typeof Model.success>>> {
     const data = await Fetcher.codashop({
       vpp: { id: "8003", price: "300000", vp: "0" },
-      user: { userId: `${id}`, zoneId: "" },
+      user: { userId: id, zoneId: "" },
       voucherTypeName: "AOV",
     });
 

--- a/src/arena-of-valor/service.ts
+++ b/src/arena-of-valor/service.ts
@@ -1,0 +1,33 @@
+import { UnwrapSchema } from "elysia";
+
+import { Model } from "./model.js";
+
+import { Fetcher } from "../utils/fetcher.js";
+import { AccountNotFoundError } from "../utils/errors.js";
+
+import { Response } from "../types/helper.js";
+
+export const ArenaOfValor = {
+  async check({ id }: UnwrapSchema<typeof Model.query>): Promise<Response<UnwrapSchema<typeof Model.success>>> {
+    const data = await Fetcher.codashop({
+      vpp: { id: "8003", price: "300000", vp: "0" },
+      user: { userId: `${id}`, zoneId: "" },
+      voucherTypeName: "AOV",
+    });
+
+    if (data.errorCode === 12) {
+      throw new AccountNotFoundError();
+    }
+
+    return {
+      success: true,
+      data: {
+        game: "Arena of Valor",
+        account: {
+          id,
+          ign: decodeURIComponent(data.confirmationFields.roles[0].role).replace(/\+/g, " "),
+        },
+      },
+    };
+  },
+};

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -12,7 +12,7 @@ export type CodashopResponse = {
   initCallBackendAPI: boolean;
   orderId: string;
   is_publisher_validate_error: boolean;
-  errorCode: string;
+  errorCode: string | number;
   confirmation: boolean;
   isUserConfirmation: boolean;
   errorMsg: string;

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -1,4 +1,4 @@
-import { t, TSchema, Static } from "elysia";
+import { t, TSchema, UnwrapSchema } from "elysia";
 
 type BadRequestExample = {
   path: string;
@@ -8,7 +8,7 @@ type BadRequestExample = {
 
 type SuccessExample<T extends Record<string, TSchema>> = {
   game: string;
-  account: { [K in keyof T]: Static<T[K]> } & { ign: string };
+  account: { [K in keyof T]: UnwrapSchema<T[K]> } & { ign: string };
 };
 
 export const Model = {


### PR DESCRIPTION
This pull request introduces support for the "Arena of Valor" game, improves input validation for account IDs, and makes minor enhancements to error handling and type safety. The changes include the addition of a new endpoint for Arena of Valor, stricter ID validation patterns, and updates for consistency in error and type handling.

**New Arena of Valor game support:**

* Added full implementation for Arena of Valor, including the endpoint (`/arena-of-valor`), request validation, response schema, and service logic for account checking. This includes new files: `src/arena-of-valor/index.ts`, `src/arena-of-valor/model.ts`, and `src/arena-of-valor/service.ts`. [[1]](diffhunk://#diff-a05c6e6e326b6d546fa0fd5158b4ae1030b12fb79f44316aa4d9808852720c1eR1-R35) [[2]](diffhunk://#diff-14709c87ca8a3aed0d97c52dd45ead56f1b618f281fc4a2fb6ffc2670679137bR1-R28) [[3]](diffhunk://#diff-bd53128c9e219bda137552531398e99f6e3fa0066bb16cec9fb5cc639d4af2b7R1-R33)

**Input validation improvements:**

* Updated the `id` field in the 8 Ball Pool and Arena of Valor models to require numeric-only strings using a regex pattern, ensuring only valid account IDs are accepted. (`src/8-ball-pool/model.ts`, `src/arena-of-valor/model.ts`) [[1]](diffhunk://#diff-5ee3210b1cb122d62e3688e6925254a392215e5548f8e391d01c19039e89e946L7-R7) [[2]](diffhunk://#diff-14709c87ca8a3aed0d97c52dd45ead56f1b618f281fc4a2fb6ffc2670679137bR1-R28)

**Error handling and response consistency:**

* Simplified and standardized validation error formatting in the 8 Ball Pool endpoint to always return all validation errors, not just those of a specific type. (`src/8-ball-pool/index.ts`)
* Updated the 8 Ball Pool service to compare error codes using strict equality and clarified the return type for better type safety. (`src/8-ball-pool/service.ts`)

**Type and utility enhancements:**

* Allowed `errorCode` to be either a string or a number in the shared Codashop response type for broader compatibility. (`src/types/shared.ts`)
* Switched from `Static` to `UnwrapSchema` for type inference in success response examples for better type accuracy. (`src/utils/model.ts`) [[1]](diffhunk://#diff-eee9f9f49826ee35c16c77d186ccc146504b9f777ebae50194fd85a91ce5015aL1-R1) [[2]](diffhunk://#diff-eee9f9f49826ee35c16c77d186ccc146504b9f777ebae50194fd85a91ce5015aL11-R11)