### PR TITLE
Add arena-of-valor routes to API group

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,12 @@ import { openapi } from "@elysiajs/openapi";
 import { config } from "./utils/config.js";
 
 import eightBallPool from "./8-ball-pool/index.js";
+import aov from "./arena-of-valor/index.js";
 
 const app = new Elysia()
   .use(cors(config.cors))
   .use(openapi(config.openapi))
-  .group("/api", (app) => app.use(eightBallPool))
+  .group("/api", (app) => app.use(eightBallPool).use(aov))
   .get("/", ({ redirect }) => redirect("/openapi"));
 
 if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
This pull request updates the API routing in `src/index.ts` to include a new module for Arena of Valor alongside the existing 8 Ball Pool module. The most important change is the addition of the Arena of Valor API routes under the `/api` group.

API routing updates:

* Added import for the new `arena-of-valor` module (`aov`) and included it in the `/api` group, so its endpoints are now available in the API.