### PR TITLE
Refactor imports and add game routes for Asphalt 9: Legends

### DIFF
--- a/src/8-ball-pool/index.ts
+++ b/src/8-ball-pool/index.ts
@@ -1,8 +1,9 @@
 import { Elysia } from "elysia";
 
 import { Model } from "./model.js";
-import { Error } from "../utils/model.js";
 import { EightBallPool } from "./service.js";
+
+import { Error } from "../utils/model.js";
 
 export default new Elysia().get("/8-ball-pool", ({ query: { id } }) => EightBallPool.check({ id }), {
   query: Model.query,

--- a/src/8-ball-pool/service.ts
+++ b/src/8-ball-pool/service.ts
@@ -1,6 +1,7 @@
 import { UnwrapSchema } from "elysia";
 
 import { Model } from "./model.js";
+
 import { Fetcher } from "../utils/fetcher.js";
 import { AccountNotFoundError } from "../utils/errors.js";
 

--- a/src/arena-of-valor/index.ts
+++ b/src/arena-of-valor/index.ts
@@ -1,9 +1,9 @@
 import { Elysia } from "elysia";
 
 import { Model } from "./model.js";
+import { ArenaOfValor } from "./service.js";
 
 import { Error } from "../utils/model.js";
-import { ArenaOfValor } from "./service.js";
 
 export default new Elysia().get("/arena-of-valor", ({ query: { id } }) => ArenaOfValor.check({ id }), {
   query: Model.query,

--- a/src/asphalt-9-legends/index.ts
+++ b/src/asphalt-9-legends/index.ts
@@ -1,0 +1,35 @@
+import { Elysia } from "elysia";
+
+import { Model } from "./model.js";
+import { Asphalt9Legends } from "./service.js";
+
+import { Error } from "../utils/model.js";
+
+export default new Elysia().get("/asphalt-9-legends", ({ query }) => Asphalt9Legends.check(query), {
+  query: Model.query,
+  response: {
+    200: Model.success,
+    400: Model.badRequest,
+    404: Error.notFound,
+    503: Error.serverError,
+  },
+  error({ error, code, set }) {
+    if (code === "VALIDATION") {
+      set.status = "Bad Request";
+
+      return {
+        success: false,
+        errors: error.all.map((e) => ({
+          path: e.path,
+          message: e.message,
+          summary: e.summary,
+        })),
+      };
+    }
+  },
+  detail: {
+    summary: "Asphalt 9: Legends",
+    description:
+      "game balap mobile yang dikembangkan oleh Gameloft, di mana pemain mengendarai mobil-mobil ikonik dari merek ternama dunia dalam balapan aksi penuh kecepatan dan trik udara spektakuler",
+  },
+});

--- a/src/asphalt-9-legends/model.ts
+++ b/src/asphalt-9-legends/model.ts
@@ -5,7 +5,7 @@ import { Model as BaseModel, Error } from "../utils/model.js";
 export const Model = {
   query: BaseModel.query({
     id: t.String({ description: "ID akun", example: "3e031e" }),
-    platform: t.UnionEnum(["ios", "android", "windows"], { default: "ios", description: "Platform" }),
+    platform: t.UnionEnum(["ios", "android", "windows"], { description: "Platform" }),
   }),
   success: BaseModel.success(
     {

--- a/src/asphalt-9-legends/model.ts
+++ b/src/asphalt-9-legends/model.ts
@@ -1,0 +1,29 @@
+import { t } from "elysia";
+
+import { Model as BaseModel, Error } from "../utils/model.js";
+
+export const Model = {
+  query: BaseModel.query({
+    id: t.String({ description: "ID akun", example: "3e031e" }),
+    platform: t.UnionEnum(["ios", "android", "windows"], { default: "ios", description: "Platform" }),
+  }),
+  success: BaseModel.success(
+    {
+      id: t.String({ description: "ID akun yang dicari" }),
+    },
+    {
+      game: "Asphalt 9: Legends",
+      account: {
+        id: "3e031e",
+        ign: "3e031e",
+      },
+    },
+  ),
+  badRequest: Error.badRequest([
+    {
+      path: "/id",
+      message: "Expected string",
+      summary: "Expected property 'id' to be string but found: undefined",
+    },
+  ]),
+};

--- a/src/asphalt-9-legends/service.ts
+++ b/src/asphalt-9-legends/service.ts
@@ -1,0 +1,35 @@
+import { UnwrapSchema } from "elysia";
+
+import { Model } from "./model.js";
+
+import { Fetcher } from "../utils/fetcher.js";
+import { AccountNotFoundError } from "../utils/errors.js";
+
+import { Response } from "../types/helper.js";
+
+type Success = Response<UnwrapSchema<typeof Model.success>>;
+
+export const Asphalt9Legends = {
+  async check({ id, platform }: UnwrapSchema<typeof Model.query>): Promise<Success> {
+    const data = await Fetcher.codashop({
+      vpp: { id: "114548", price: "479700", vp: "0" },
+      user: { userId: id, zoneId: platform },
+      voucherTypeName: "GAMELOFT_A9",
+    });
+
+    if (data.errorCode === "-100") {
+      throw new AccountNotFoundError();
+    }
+
+    return {
+      success: true,
+      data: {
+        game: "Asphalt 9: Legends",
+        account: {
+          id,
+          ign: decodeURIComponent(data.confirmationFields.username).replace(/\+/g, " "),
+        },
+      },
+    };
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,12 @@ import { config } from "./utils/config.js";
 
 import eightBallPool from "./8-ball-pool/index.js";
 import aov from "./arena-of-valor/index.js";
+import asphalt9Legends from "./asphalt-9-legends/index.js";
 
 const app = new Elysia()
   .use(cors(config.cors))
   .use(openapi(config.openapi))
-  .group("/api", (app) => app.use(eightBallPool).use(aov))
+  .group("/api", (app) => app.use(eightBallPool).use(aov).use(asphalt9Legends))
   .get("/", ({ redirect }) => redirect("/openapi"));
 
 if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
This pull request adds support for the "Asphalt 9: Legends" game to the API, including a new endpoint, request/response validation, and error handling. It also includes minor import cleanups in existing modules for consistency.

**New Asphalt 9: Legends API support:**

* Added a new endpoint `/api/asphalt-9-legends` with request validation, error handling, and OpenAPI documentation in `asphalt-9-legends/index.ts`. [[1]](diffhunk://#diff-0dcf375b8d6563743c1f92d6443e04c36492707e0e008ef485e8b3a5f1f961d6R1-R35) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R9-R14)
* Implemented the `Asphalt9Legends` service for account checking, integrating with the Codashop API and handling account not found errors in `asphalt-9-legends/service.ts`.
* Defined request and response schemas, including validation and error models for Asphalt 9: Legends in `asphalt-9-legends/model.ts`.

**Import and code organization improvements:**

* Standardized and reordered imports in `8-ball-pool/index.ts` and `arena-of-valor/index.ts` for better clarity and maintainability. [[1]](diffhunk://#diff-851c68be49b9e545a69d068113cf598cf4b5e8c3b18c09ae3f446f679a3d5ac2L4-R7) [[2]](diffhunk://#diff-a05c6e6e326b6d546fa0fd5158b4ae1030b12fb79f44316aa4d9808852720c1eR4-L6)
* Minor formatting improvement in `8-ball-pool/service.ts` for import separation.